### PR TITLE
Refactor: Eliminar funcionalidad de saldo Sky y mejorar lógica de cortes

### DIFF
--- a/sistema_cmg.html
+++ b/sistema_cmg.html
@@ -68,7 +68,7 @@
         const GOOGLE_SHEET_ID = '1YourSheetIdHere'; // ⚠️ REEMPLAZAR CON TU ID REAL
 
         // Constantes para evitar "magic numbers" y strings repetitivos
-        const PAQUETERIAS = ['fedex', 'estafeta', 'dhl'];
+        const PAQUETERIAS = ['fedex', 'estafeta'];
         const PAQUETERIAS_ENTREGA = ['mercado libre', 'amazon', 'shein', 'temu', 'ali express', 'otra'];
         const TIPOS_SERVICIO = ['nacional', 'internacional'];
         const TIPOS_OPERACION = ['envio', 'devolucion', 'entrega'];
@@ -399,7 +399,7 @@
                 // Tabla de declaración
                 declaraciones: [{ cantidad: '', producto: '', costo: '', peso: '' }],
                 // Paquetería de pago
-                paqueteriaPago: 'dhl'
+                paqueteriaPago: 'fedex'
             });
 
             // Estados para modal de edición
@@ -1384,7 +1384,7 @@
                     horaLiberacion: '',
                     estadoEntrega: 'pendiente',
                     declaraciones: [{ cantidad: '', producto: '', costo: '', peso: '' }],
-                    paqueteriaPago: 'dhl'
+                    paqueteriaPago: 'fedex'
                 });
 
                 // Resetear campos de pago en efectivo


### PR DESCRIPTION
- Eliminar campo de Saldo Sky del formulario de apertura de turno
- Remover display de saldo Sky del turno actual
- Eliminar selector de paquetería Sky/DHL
- Remover lógica de descuento de saldo Sky en ventas
- Eliminar campos saldo_inicial y saldo_actual de la estructura de turno
- Refactorizar completamente la lógica de cortes diarios:
  * Ingresos: Ahora incluye fondo inicial en caja + ventas realizadas
  * Egresos: Solo gastos totales
  * Balance Real: Fondo inicial + ventas - gastos
  * Balance Declarado: Suma de billetes y monedas declarados por el cajero
  * Diferencia: Muestra sobrante (positivo) o faltante (negativo)
- Agregar aviso visual prominente cuando hay diferencias entre real y declarado
- Mejorar visualización de declaración de billetes con totales por denominación