### PR TITLE
Fix: Corregir registro de fechas en historial y confirmar funcionalid…

### DIFF
--- a/sistema_cmg.html
+++ b/sistema_cmg.html
@@ -646,7 +646,7 @@
                         // Convertir las ventas de Sheets al formato de la app
                         const ventasConvertidas = ventasSheets.map(v => ({
                             id: v.numeroGuia || `ENV-${Date.now()}`,
-                            fecha: new Date().toISOString(), // Usar fecha actual como respaldo
+                            fecha: v.fecha || v.fechaRegistro || new Date().toISOString(), // Usar fecha original de Sheets
                             nombreRemitente: v.remitente,
                             telefonoRemitente: v.telRemitente,
                             nombreDestinatario: v.destinatario,


### PR DESCRIPTION
…ades existentes

- Corregir línea 649: usar fecha original de Google Sheets en lugar de fecha actual
  * Ahora preserva v.fecha o v.fechaRegistro de Google Sheets
  * Solo usa fecha actual como respaldo si no existe fecha en Sheets
  * Esto corrige el problema donde todas las ventas aparecían con la misma fecha

- Confirmar funcionalidades ya implementadas:
  * Sistema de cortes ya muestra cobros con tarjeta (🏦 Ventas Banco)
  * Sistema de cortes ya cuadra tarjeta con venta total
  * Gastos y salidas ya tienen campo de método de pago (Efectivo/Tarjeta)

Resuelve el problema de fechas duplicadas en el historial de ventas.