### PR TITLE
Fix sales ranking calculation and data storage

### DIFF
--- a/sistema_cmg.html
+++ b/sistema_cmg.html
@@ -1811,8 +1811,8 @@
                     };
                 });
 
-                // Ordenar por cantidad de ventas (mayor a menor)
-                return estadisticas.sort((a, b) => b.cantidadVentas - a.cantidadVentas);
+                // Ordenar por total vendido (mayor a menor) para reflejar el rendimiento real
+                return estadisticas.sort((a, b) => b.totalVentas - a.totalVentas);
             };
 
             // Función para obtener el vendedor del mes


### PR DESCRIPTION
Cambia el criterio de ordenamiento del ranking de vendedores para que ordene por total vendido (totalVentas) en lugar de por cantidad de ventas (cantidadVentas). Esto refleja mejor el rendimiento real de cada vendedor, ya que un vendedor con pocas ventas grandes debe estar por encima de uno con muchas ventas pequeñas.